### PR TITLE
Instanceof null fix

### DIFF
--- a/cps-interpreter.coffee
+++ b/cps-interpreter.coffee
@@ -177,7 +177,7 @@ interp = (node, env=new Environment, cont, errCont) ->
           errCont new ReturnException result
       when 'ThrowStatement'
         await interp node.argument, env, defer(result), errCont
-        errCont new JSException result
+        errCont new JSException result, node
       when 'TryStatement'
         interp node.block, env, cont, (e) ->
           if e instanceof JSException and node.handlers.length > 0
@@ -233,7 +233,7 @@ interp = (node, env=new Environment, cont, errCont) ->
           when '!=='
             cont(`lhs !== rhs`)
           when 'instanceof'
-            cont(lhs instanceof rhs.__ctor__)
+            cont(lhs instanceof (rhs?.__ctor__ ? rhs))
           else
             errCont("Unrecognized operator #{node.operator}")
       when 'AssignmentExpression'
@@ -325,10 +325,9 @@ interp = (node, env=new Environment, cont, errCont) ->
         console.log node
         errCont('Unrecognized node!')
   catch e
-    unless e instanceof InterpreterException
-      console.log "Line #{node.loc.start.line}: Error in #{node.type}"
+    if e not instanceof JSException && e not instanceof InterpreterException
+      e = new JSException e, node
     errCont(e)
-  return
 
 evalMemberExpr = (node, env, cont, errCont) ->
   await interp node.object, env, defer(object), errCont
@@ -367,7 +366,10 @@ toplevel = ->
   env = new Environment
   repl.start
     eval: (cmd, ctx, filename, callback) ->
-      await interp (esprima.parse cmd[1..-2], loc: true), env, callback, callback
+      await interp (esprima.parse cmd[1..-2], loc: true), env, callback, (e) ->
+        if(e instanceof JSException)
+          console.log("Line #{e.node.loc.start.line}: Error in #{e.node.type}")
+        e?.exception ? e
 
 if require.main is module
   {argv} = require 'optimist'

--- a/cps-interpreter.coffee
+++ b/cps-interpreter.coffee
@@ -325,7 +325,7 @@ interp = (node, env=new Environment, cont, errCont) ->
         console.log node
         errCont('Unrecognized node!')
   catch e
-    if e not instanceof JSException && e not instanceof InterpreterException
+    if e not instanceof InterpreterException
       e = new JSException e, node
     errCont(e)
 

--- a/cps-interpreter.coffee
+++ b/cps-interpreter.coffee
@@ -369,7 +369,7 @@ toplevel = ->
       await interp (esprima.parse cmd[1..-2], loc: true), env, callback, (e) ->
         if(e instanceof JSException)
           console.log("Line #{e.node.loc.start.line}: Error in #{e.node.type}")
-        e?.exception ? e
+        callback(e?.exception ? e)
 
 if require.main is module
   {argv} = require 'optimist'

--- a/interpreter.coffee
+++ b/interpreter.coffee
@@ -144,7 +144,7 @@ interp = (node, env=new Environment) ->
         throw new ReturnException undefined if node.argument is null
         throw new ReturnException interp node.argument, env
       when 'ThrowStatement'
-        throw new JSException (interp node.argument), node
+        throw new JSException (interp node.argument, env), node
       when 'TryStatement'
         try
           interp node.block, env

--- a/interpreter.coffee
+++ b/interpreter.coffee
@@ -293,7 +293,7 @@ interp = (node, env=new Environment) ->
         console.log "Unrecognized node!"
         console.log node
   catch e
-    if e not instanceof JSException && e not instanceof InterpreterException
+    if e not instanceof InterpreterException
       e = new JSException e, node
     throw e
 

--- a/tests/reflection.js
+++ b/tests/reflection.js
@@ -41,3 +41,10 @@ var __proto__ = null;
 console.log(__proto__);
 console.log(toString);
 console.log(global.__proto__);
+
+console.log("invalid instanceof call");
+try {
+    1 instanceof null;
+} catch (e) {
+    console.log(e);
+}

--- a/util/interp-util.coffee
+++ b/util/interp-util.coffee
@@ -26,7 +26,7 @@ class root.BreakException extends root.InterpreterException
 class root.ContinueException extends root.InterpreterException
 
 class root.JSException extends root.InterpreterException
-  constructor: (@exception) ->
+  constructor: (@exception, @node) ->
 
 class root.Environment
   constructor: (@scopeChain=[new Map], @currentScope=0, @strict=false) ->


### PR DESCRIPTION
This is a fix for the following test:

try {
    1 instanceof null;
} catch (e) {
    console.log(e);
}

There is a minor change in the way instanceof works (to check for null).  I also changed the way that exceptions are handled so that errors that are explicitly thrown can be accurately logged (which was needed to get the test to pass).
