### PR TITLE
Code to bring back JSException

### DIFF
--- a/lib/interpreter.coffee
+++ b/lib/interpreter.coffee
@@ -17,6 +17,7 @@ class YieldException extends InterpreterException
 
 class JSException
   constructor: (@error, @node, @env) ->
+  toString: -> @error.toString()
 
 class StopIteration
   constructor: (@value) ->

--- a/repl.coffee
+++ b/repl.coffee
@@ -1,5 +1,4 @@
 #! /usr/bin/env iced
-
 {evaluate,Environment} = require './lib/interpreter'
 esprima = require 'esprima'
 


### PR DESCRIPTION
This code brings back JSException (if you're okay with it) -- I think JSException can carry useful metadata about the exception (node and environment) which can be useful for debuging.

I also wrote an issue for this: https://github.com/int3/metajs/issues/8
