### PR TITLE
Update README.md to reflect new filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Usage
 
 To start the REPL:
 
-    ./interpreter.coffee
+    ./repl.coffee
 
 To execute a file:
 
-    ./interpreter.coffee [filename]
+    ./repl.coffee [filename]
 
 To run in the browser:
 


### PR DESCRIPTION
'Getting Started' instructions currently refer to a non-existent 'interpreter.coffee' file. They should reference the 'repl.coffee' file. This pr fixes that.
